### PR TITLE
Add live theme switching support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.10</version>
+        <version>4.34</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,7 +14,7 @@
     <properties>
         <revision>0.2</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.248</jenkins.version>
+        <jenkins.version>2.336-rc32081.db_eed62c0c0e</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -24,8 +24,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>13</version>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1155.v77b_fd92a_26fc</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>theme-manager</artifactId>
-            <version>0.5</version>
+            <version>0.7-rc94.26a_5398f092d</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.34</version>
+        <version>4.37</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,7 +14,7 @@
     <properties>
         <revision>0.2</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.336-rc32081.db_eed62c0c0e</jenkins.version>
+        <jenkins.version>2.336</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -24,7 +24,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
+                <artifactId>bom-2.332.x</artifactId>
                 <version>1155.v77b_fd92a_26fc</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>theme-manager</artifactId>
-            <version>0.7-rc94.26a_5398f092d</version>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/solarizedtheme/AbstractSolarizedThemeDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/solarizedtheme/AbstractSolarizedThemeDescriptor.java
@@ -10,4 +10,9 @@ public abstract class AbstractSolarizedThemeDescriptor extends ThemeManagerFacto
     public String getThemeId() {
         return ID;
     }
+
+    @Override
+    public boolean isNamespaced() {
+        return true;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedDarkTheme.java
+++ b/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedDarkTheme.java
@@ -18,9 +18,15 @@ public class SolarizedDarkTheme extends AbstractSolarizedTheme {
     @Extension
     @Symbol("solarizedDark")
     public static class DescriptorImpl extends AbstractSolarizedThemeDescriptor {
+
+        @Override
+        public String getThemeKey() {
+            return "solarized-dark";
+        }
+
         @Override
         public ThemeManagerFactory getInstance() {
-            return new SolarizedLightTheme();
+            return new SolarizedDarkTheme();
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedLightTheme.java
+++ b/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedLightTheme.java
@@ -18,6 +18,12 @@ public class SolarizedLightTheme extends AbstractSolarizedTheme {
     @Extension
     @Symbol("solarizedLight")
     public static class DescriptorImpl extends AbstractSolarizedThemeDescriptor {
+
+        @Override
+        public String getThemeKey() {
+            return "solarized";
+        }
+
         @Override
         public ThemeManagerFactory getInstance() {
             return new SolarizedLightTheme();

--- a/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedRootAction.java
+++ b/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedRootAction.java
@@ -36,7 +36,7 @@ public class SolarizedRootAction implements UnprotectedRootAction {
         if (cssFile.startsWith("/")) {
             cssFile = cssFile.substring(1);
         }
-        if (!Arrays.asList(AbstractSolarizedTheme.BASE_CSS, AbstractSolarizedTheme.DEFINITIONS_CSS, SolarizedSystemTheme.CSS, SolarizedLightTheme.CSS, SolarizedDarkTheme.CSS).contains(cssFile)) {
+        if (!Arrays.asList(AbstractSolarizedTheme.BASE_CSS, AbstractSolarizedTheme.DEFINITIONS_CSS, SolarizedLightTheme.CSS, SolarizedDarkTheme.CSS).contains(cssFile)) {
             rsp.sendError(404);
             return;
         }

--- a/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedSystemTheme.java
+++ b/src/main/java/io/jenkins/plugins/solarizedtheme/SolarizedSystemTheme.java
@@ -2,30 +2,35 @@ package io.jenkins.plugins.solarizedtheme;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import io.jenkins.plugins.thememanager.Theme;
 import io.jenkins.plugins.thememanager.ThemeManagerFactory;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class SolarizedSystemTheme extends AbstractSolarizedTheme {
 
-    public static final String CSS = "solarized-system.css";
-
     @DataBoundConstructor
     public SolarizedSystemTheme() {
         // Stapler
     }
 
+    @Override
+    public Theme getTheme() {
+        return Theme.builder().build();
+    }
+
     @Extension
     @Symbol("solarizedSystem")
     public static class DescriptorImpl extends AbstractSolarizedThemeDescriptor {
+
         @Override
-        public ThemeManagerFactory getInstance() {
-            return new SolarizedSystemTheme();
+        public String getThemeKey() {
+            return "solarized-system";
         }
 
         @Override
-        public String getThemeCssSuffix() {
-            return CSS;
+        public ThemeManagerFactory getInstance() {
+            return new SolarizedSystemTheme();
         }
 
         @NonNull

--- a/src/main/webapp/solarized-base.css
+++ b/src/main/webapp/solarized-base.css
@@ -19,7 +19,7 @@ cyan      #2aa198  6/6 cyan      37 #00afaf 60 -35 -05  42 161 152 175  74  63
 green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 */
 
-:root {
+[data-theme=solarized], .app-theme-picker__picker[data-theme=solarized], [data-theme=solarized-dark], .app-theme-picker__picker[data-theme=solarized-dark], [data-theme=solarized-system], .app-theme-picker__picker[data-theme=solarized-system] {
   --solarized-base03:  #002b36;
   --solarized-base02:  #073642;
   --solarized-base01:  #586e75;

--- a/src/main/webapp/solarized-dark.css
+++ b/src/main/webapp/solarized-dark.css
@@ -1,7 +1,17 @@
-:root {
+[data-theme=solarized-dark], .app-theme-picker__picker[data-theme=solarized-dark] {
   --solarized-emphasized: var(--solarized-base1);
   --solarized-primary: var(--solarized-base0);
   --solarized-secondary: var(--solarized-base01);
   --solarized-bg-highlights: var(--solarized-base02);
   --solarized-bg: var(--solarized-base03);
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-theme=solarized-system], .app-theme-picker__picker[data-theme=solarized-system] {
+    --solarized-emphasized: var(--solarized-base1);
+    --solarized-primary: var(--solarized-base0);
+    --solarized-secondary: var(--solarized-base01);
+    --solarized-bg-highlights: var(--solarized-base02);
+    --solarized-bg: var(--solarized-base03);
+  }
 }

--- a/src/main/webapp/solarized-definitions.css
+++ b/src/main/webapp/solarized-definitions.css
@@ -1,4 +1,4 @@
-:root {
+[data-theme=solarized], .app-theme-picker__picker[data-theme=solarized], [data-theme=solarized-dark], .app-theme-picker__picker[data-theme=solarized-dark], [data-theme=solarized-system], .app-theme-picker__picker[data-theme=solarized-system] {
   --add-item-btn-decorator-bg-color: var(--solarized-bg-highlights);                                                    /* background color of the area around the "OK" button on "New Item" dialog */
   --add-item-btn-decorator-border-color: var(--solarized-bg-highlights);                                                /* border color of the area around the "OK" button on "New Item" dialog */
   --alert-danger-bg-color: var(--solarized-red);

--- a/src/main/webapp/solarized-definitions.css
+++ b/src/main/webapp/solarized-definitions.css
@@ -71,7 +71,7 @@
   /* --font-size-monospace */                                                                                           /* not a color */
   /* --font-size-sm */                                                                                                  /* not a color */
   /* --font-size-xs */                                                                                                  /* not a color */
-  /* --header-bg-classic */
+  --header-bg-classic: #000;
   --header-bg-v2: var(--solarized-secondary);
   /* --header-item-border-radius */
   /* --header-link-bg-active-v2 */

--- a/src/main/webapp/solarized-light.css
+++ b/src/main/webapp/solarized-light.css
@@ -1,7 +1,17 @@
-:root {
+[data-theme=solarized], .app-theme-picker__picker[data-theme=solarized] {
   --solarized-emphasized: var(--solarized-base01);
   --solarized-primary: var(--solarized-base00);
   --solarized-secondary: var(--solarized-base1);
   --solarized-bg-highlights: var(--solarized-base2);
   --solarized-bg: var(--solarized-base3);
+}
+
+@media (prefers-color-scheme: light) {
+  [data-theme=solarized-system], .app-theme-picker__picker[data-theme=solarized-system] {
+    --solarized-emphasized: var(--solarized-base01);
+    --solarized-primary: var(--solarized-base00);
+    --solarized-secondary: var(--solarized-base1);
+    --solarized-bg-highlights: var(--solarized-base2);
+    --solarized-bg: var(--solarized-base3);
+  }
 }

--- a/src/main/webapp/solarized-system.css
+++ b/src/main/webapp/solarized-system.css
@@ -1,2 +1,0 @@
-@import url('solarized-dark.css') (prefers-color-scheme: dark);
-@import url('solarized-light.css') not (prefers-color-scheme: dark);


### PR DESCRIPTION
See https://github.com/jenkinsci/theme-manager-plugin/pull/75

All themes are now loaded on every page, the active theme is controlled by a `data` attribute on the `html` element.

Given not many variables are overridden for the `light` / `dark` themes I just duplicated them below each other.
If that's not wanted then I can introduce some preprocessing like done in the Dark theme PR https://github.com/jenkinsci/dark-theme-plugin/pull/170

FYI @janfaracik 

