### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(useContainerAgent: true)


### PR DESCRIPTION
The useAci option is deprecated in favor of useContainerAgent.
This PR updates the deprecated reference.